### PR TITLE
Fix case-insensitive regex compilation

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -102,18 +102,20 @@ func compileRule(r db.Rule) (CompiledRule, error) {
 		Texts:         texts,
 	}
 
-	if !cr.CaseSensitive {
-		for i, t := range cr.Texts {
-			cr.Texts[i] = strings.ToLower(t)
-		}
-	}
-
 	if cr.Kind == "regex" {
-		re, err := regexp.Compile(cr.Texts[0])
+		pattern := cr.Texts[0]
+		if !cr.CaseSensitive {
+			pattern = "(?i)" + pattern
+		}
+		re, err := regexp.Compile(pattern)
 		if err != nil {
 			return CompiledRule{}, err
 		}
 		cr.Regexp = re
+	} else if !cr.CaseSensitive {
+		for i, t := range cr.Texts {
+			cr.Texts[i] = strings.ToLower(t)
+		}
 	}
 
 	return cr, nil

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -1,0 +1,43 @@
+package classifier
+
+import (
+	"encoding/json"
+	"testing"
+
+	"kalycs/db"
+)
+
+func TestCompileRuleRegexCaseInsensitive(t *testing.T) {
+	texts, _ := json.Marshal([]string{"test"})
+	rule := db.Rule{Rule: "regex", Texts: string(texts), CaseSensitive: false}
+	cr, err := compileRule(rule)
+	if err != nil {
+		t.Fatalf("compileRule returned error: %v", err)
+	}
+	if cr.Regexp == nil {
+		t.Fatalf("compiled regexp is nil")
+	}
+
+	if !cr.Regexp.MatchString("TEST") {
+		t.Errorf("compiled regex should match case-insensitively")
+	}
+	if !cr.Regexp.MatchString("test") {
+		t.Errorf("compiled regex should match lowercase string")
+	}
+}
+
+func TestMatchesRegexCaseInsensitive(t *testing.T) {
+	texts, _ := json.Marshal([]string{"^file"})
+	rule := db.Rule{Rule: "regex", Texts: string(texts), CaseSensitive: false}
+	cr, err := compileRule(rule)
+	if err != nil {
+		t.Fatalf("compileRule returned error: %v", err)
+	}
+
+	if !matches(cr, "FILE.TXT", "txt") {
+		t.Errorf("regex rule should match filename regardless of case")
+	}
+	if !matches(cr, "file.txt", "txt") {
+		t.Errorf("regex rule should match lowercase filename")
+	}
+}


### PR DESCRIPTION
## Summary
- ensure regex rules use case-insensitive flag when `CaseSensitive` is false
- add classifier tests for case-insensitive regex matching

## Testing
- `go test ./...` *(fails: Get https://proxy.golang.org/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6868da72d00883279306c243ed3e244c